### PR TITLE
Small typo fix for codeigniter completions

### DIFF
--- a/PHP-codeigniter.sublime-completions
+++ b/PHP-codeigniter.sublime-completions
@@ -303,7 +303,7 @@
     { "trigger": "\\$this->db->set", "contents": "\\$this->db->set(${1:'field', 'field2', FALSE})" },
     { "trigger": "\\$this->db->uodate", "contents": "\\$this->db->uodate(${1:table, \\$data})" },
     { "trigger": "\\$this->db->update_batch", "contents": "\\$this->db->update_batch(${1:table_name, array, where_key})" },
-    { "trigger": "\\$this->db->delete", "contents": "\\$this->db->delete(${1:table_name, where_clause)" },
+    { "trigger": "\\$this->db->delete", "contents": "\\$this->db->delete(${1:table_name, where_clause})" },
     { "trigger": "\\$this->db->empty_table", "contents": "\\$this->db->empty_table(${1:table_name})" },
     { "trigger": "\\$this->db->truncate", "contents": "\\$this->db->truncate(${1:blank or table_name})" },
     { "trigger": "\\$this->db->start_cache", "contents": "\\$this->db->start_cache()" },


### PR DESCRIPTION
Hi, I found a minor bug with the db->delete completion, closing } was missing meaning the completion didn't work.

Not sure if you want pull-requests for fixes, so feel free to ignore, I have fixed in this fork though.

Thanks.
